### PR TITLE
Add port to docker config so the microservice registers correctly with Control Tower locally

### DIFF
--- a/docker-compose-develop.yml
+++ b/docker-compose-develop.yml
@@ -12,6 +12,7 @@ services:
       CT_TOKEN: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6Im1pY3Jvc2VydmljZSIsImNyZWF0ZWRBdCI6IjIwMTYtMDktMTQifQ.IRCIRm1nfIQTfda_Wb6Pg-341zhV8soAgzw7dd5HxxQ
       API_VERSION: v1
       FASTLY_ENABLED: "false"
+      PORT: 3055
     command: develop
     volumes:
       - ./app:/opt/adapter-arcgis/app


### PR DESCRIPTION
I have made a series of small changes which ensures that the microservices build and register with the Control Tower locally with Docker.

The changes to this repo are:
- Set the port this service runs on